### PR TITLE
Fix failing user-agent spec

### DIFF
--- a/lib/soundcloud/client.rb
+++ b/lib/soundcloud/client.rb
@@ -1,7 +1,9 @@
+require 'soundcloud/version'
+
 module SoundCloud
   class Client
     include HTTMultiParty
-    USER_AGENT            = "SoundCloud Ruby Wrapper #{VERSION}"
+    USER_AGENT            = "SoundCloud Ruby Wrapper #{SoundCloud::VERSION}"
     CLIENT_ID_PARAM_NAME  = :client_id
     API_SUBHOST           = 'api'
     AUTHORIZE_PATH        = '/connect'


### PR DESCRIPTION
In my environment, "rake spec" is failed

````zsh
% rake spec
/Users/****/.rbenv/versions/2.2.0/bin/ruby -I/Users/****/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-support-3.2.1/lib:/Users/****/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.2.0/lib /Users/****/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/rspec-core-3.2.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 12508
........................F..............................F......F......

Failures:

  1) SoundCloud initialized with a client id #delete sends a user agent header
     Failure/Error: expect(WebMock.last_request.headers["User-Agent"]).to eq("SoundCloud Ruby Wrapper #{SoundCloud::VERSION}")
       
       expected: "SoundCloud Ruby Wrapper 0.3.2"
            got: "SoundCloud Ruby Wrapper 0.13.3"
       
       (compared using ==)
     # ./spec/soundcloud_spec.rb:95:in `block (5 levels) in <top (required)>'

  2) SoundCloud initialized with a client id #get sends a user agent header
     Failure/Error: expect(WebMock.last_request.headers["User-Agent"]).to eq("SoundCloud Ruby Wrapper #{SoundCloud::VERSION}")
       
       expected: "SoundCloud Ruby Wrapper 0.3.2"
            got: "SoundCloud Ruby Wrapper 0.13.3"
       
       (compared using ==)
     # ./spec/soundcloud_spec.rb:95:in `block (5 levels) in <top (required)>'

  3) SoundCloud initialized with a client id #head sends a user agent header
     Failure/Error: expect(WebMock.last_request.headers["User-Agent"]).to eq("SoundCloud Ruby Wrapper #{SoundCloud::VERSION}")
       
       expected: "SoundCloud Ruby Wrapper 0.3.2"
            got: "SoundCloud Ruby Wrapper 0.13.3"
       
       (compared using ==)
     # ./spec/soundcloud_spec.rb:95:in `block (5 levels) in <top (required)>'

Finished in 0.28117 seconds (files took 0.90049 seconds to load)
69 examples, 3 failures

Failed examples:

rspec ./spec/soundcloud_spec.rb:91 # SoundCloud initialized with a client id #delete sends a user agent header
rspec ./spec/soundcloud_spec.rb:91 # SoundCloud initialized with a client id #get sends a user agent header
rspec ./spec/soundcloud_spec.rb:91 # SoundCloud initialized with a client id #head sends a user agent header
````

I think "0.13.3" is httpparty gem's version

````zsh
-% rbenv exec bundle show
Gems included by the bundle:
  * addressable (2.3.7)
  * bundler (1.8.0)
  * crack (0.4.2)
  * diff-lcs (1.2.5)
  * docile (1.1.5)
  * hashie (2.1.2)
  * httmultiparty (0.3.16)
  * httparty (0.13.3)
  * json (1.8.2)
  * mimemagic (0.2.1)
  * multi_json (1.10.1)
  * multi_xml (0.5.5)
  * multipart-post (2.0.0)
  * rake (10.4.2)
  * rspec (3.2.0)
  * rspec-core (3.2.0)
  * rspec-expectations (3.2.0)
  * rspec-mocks (3.2.0)
  * rspec-support (3.2.1)
  * safe_yaml (1.0.4)
  * simplecov (0.9.1)
  * simplecov-html (0.8.0)
  * soundcloud (0.3.2)
  * webmock (1.20.4)
````

So, I explicitly specify sound cloud's version.