### PR TITLE
[ci skip] remove order from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem install soundcloud
 # register a client with YOUR_CLIENT_ID as client_id_
 client = SoundCloud.new(:client_id => YOUR_CLIENT_ID)
 # get 10 hottest tracks
-tracks = client.get('/tracks', :limit => 10, :order => 'hotness')
+tracks = client.get('/tracks', :limit => 10)
 # print each link
 tracks.each do |track|
   puts track.permalink_url


### PR DESCRIPTION
I spend some time figuring out why the order option wasn't working, it seems that is not used anymore: https://developers.soundcloud.com/blog/removing-hotness-param