### PR TITLE
Document version number in API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ gem install soundcloud
 ```
 
 ## Examples
+
+The following examples are for the [latest gem version](https://rubygems.org/gems/soundcloud).
+
+```ruby
+SoundCloud::VERSION
+# => "0.3.2"
+```
+
 #### Print links of the 10 hottest tracks
 ```ruby
 # register a client with YOUR_CLIENT_ID as client_id_


### PR DESCRIPTION
The interface of the library has changed between the last two patch versions and caused some confusion. This change aims at making it easier to verify the version being used.

@landonwilkins @sferik in response to #42.