### PR TITLE
Replace httmultiparty with httparty 0.16.2

### DIFF
--- a/lib/soundcloud.rb
+++ b/lib/soundcloud.rb
@@ -1,5 +1,5 @@
 require 'hashie'
-require 'httmultiparty'
+require 'httparty'
 require 'uri'
 
 require 'soundcloud/array_response_wrapper'

--- a/lib/soundcloud/client.rb
+++ b/lib/soundcloud/client.rb
@@ -2,7 +2,7 @@ require 'soundcloud/version'
 
 module SoundCloud
   class Client
-    include HTTMultiParty
+    include HTTParty
     USER_AGENT            = "SoundCloud Ruby Wrapper #{SoundCloud::VERSION}"
     CLIENT_ID_PARAM_NAME  = :client_id
     API_SUBHOST           = 'api'

--- a/lib/soundcloud/client.rb
+++ b/lib/soundcloud/client.rb
@@ -129,7 +129,7 @@ module SoundCloud
       end
       params.merge!(client_params)
       response = handle_response(false) {
-        self.class.post("https://#{api_host}#{TOKEN_PATH}", :query => params)
+        self.class.post("https://#{api_host}#{TOKEN_PATH}", :body => params)
       }
       @options.merge!(:access_token => response.access_token, :refresh_token => response.refresh_token)
       @options[:expires_at] = Time.now + response.expires_in if response.expires_in

--- a/soundcloud.gemspec
+++ b/soundcloud.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.required_rubygems_version = '>= 1.3.5'
 
-  spec.add_dependency('httmultiparty', '~> 0.3.0')
+  spec.add_dependency('httparty', '>= 0.16.2')
   spec.add_dependency('hashie')
 
   spec.add_development_dependency('bundler', '~> 1.0')

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -213,7 +213,7 @@ describe SoundCloud do
 
       it "calls authorize endpoint to exchange token and store them when refresh token is passed" do
         allow(subject.class).to receive(:post)
-        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'refresh_token',
           :refresh_token => 'refresh',
           :client_id     => 'client',
@@ -225,7 +225,7 @@ describe SoundCloud do
       end
 
       it "calls authorize endpoint to exchange token and store them when credentials are passed" do
-        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(SoundCloud::Client).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'password',
           :username      => 'foo@bar.com',
           :password      => 'pass',
@@ -238,7 +238,7 @@ describe SoundCloud do
       end
 
       it "calls authorize endpoint to exchange token and store them when code and redirect_uri are passed" do
-        expect(subject.class).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :query => {
+        expect(subject.class).to receive(:post).with('https://api.soundcloud.com/oauth2/token', :body => {
           :grant_type    => 'authorization_code',
           :redirect_uri  => 'http://somewhere.com/bla',
           :code          => 'pass',


### PR DESCRIPTION
Now that `httparty` [supports multipart uploads](https://github.com/jnunemaker/httparty/pull/569#issuecomment-378691037), its implementation is incompatible with `httmultiparty`, and `httmultiparty` is no longer maintained, this PR switches the gem to use `httparty`.